### PR TITLE
fix: some oauth endpoints need to be unprotected

### DIFF
--- a/proms_mcp/auth/middleware.py
+++ b/proms_mcp/auth/middleware.py
@@ -20,8 +20,14 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Any, call_next: Any) -> Any:
         """Process request with authentication."""
-        # Skip authentication for health checks and metrics endpoints
-        if request.url.path in ["/health", "/metrics"]:
+        # Skip authentication for health checks, metrics, and OAuth well-known endpoints
+        unprotected_paths = [
+            "/health",
+            "/metrics",
+            "/.well-known/oauth-protected-resource",
+            "/.well-known/oauth-authorization-server",
+        ]
+        if request.url.path in unprotected_paths:
             return await call_next(request)
 
         # Authenticate request

--- a/tests/auth/test_middleware.py
+++ b/tests/auth/test_middleware.py
@@ -1,0 +1,249 @@
+"""Tests for authentication middleware."""
+
+from unittest.mock import AsyncMock, Mock
+
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse, PlainTextResponse
+from starlette.testclient import TestClient
+
+from proms_mcp.auth.backends import NoAuthBackend
+from proms_mcp.auth.middleware import AuthenticationMiddleware
+from proms_mcp.auth.models import User
+
+
+class TestAuthenticationMiddleware:
+    """Test the authentication middleware."""
+
+    def test_unprotected_endpoints_no_auth_required(self) -> None:
+        """Test that unprotected endpoints don't require authentication."""
+        # Create a simple Starlette app for testing
+        app = Starlette()
+
+        @app.route("/health")
+        async def health(request: Request) -> PlainTextResponse:
+            return PlainTextResponse("OK")
+
+        @app.route("/metrics")
+        async def metrics(request: Request) -> PlainTextResponse:
+            return PlainTextResponse("# metrics")
+
+        @app.route("/.well-known/oauth-protected-resource")
+        async def oauth_protected_resource(request: Request) -> JSONResponse:
+            return JSONResponse({"resource_server": "test"})
+
+        @app.route("/.well-known/oauth-authorization-server")
+        async def oauth_authorization_server(request: Request) -> JSONResponse:
+            return JSONResponse({"issuer": "test"})
+
+        @app.route("/protected")
+        async def protected(request: Request) -> PlainTextResponse:
+            return PlainTextResponse("Protected content")
+
+        # Create a mock auth backend that always fails
+        mock_auth_backend = Mock()
+        mock_auth_backend.authenticate = AsyncMock(return_value=None)
+
+        # Add authentication middleware
+        app.add_middleware(AuthenticationMiddleware, auth_backend=mock_auth_backend)
+
+        # Create test client
+        client = TestClient(app)
+
+        # Test unprotected endpoints - should work without authentication
+        response = client.get("/health")
+        assert response.status_code == 200
+        assert response.text == "OK"
+
+        response = client.get("/metrics")
+        assert response.status_code == 200
+        assert response.text == "# metrics"
+
+        response = client.get("/.well-known/oauth-protected-resource")
+        assert response.status_code == 200
+        assert response.json() == {"resource_server": "test"}
+
+        response = client.get("/.well-known/oauth-authorization-server")
+        assert response.status_code == 200
+        assert response.json() == {"issuer": "test"}
+
+        # Test protected endpoint - should fail without authentication
+        response = client.get("/protected")
+        assert response.status_code == 401
+        assert response.json() == {"error": "Authentication required"}
+
+        # Verify that authenticate was called for protected endpoint but not unprotected ones
+        # The mock should have been called only once for the protected endpoint
+        assert mock_auth_backend.authenticate.call_count == 1
+
+    def test_protected_endpoint_with_valid_auth(self) -> None:
+        """Test that protected endpoints work with valid authentication."""
+        # Create a simple Starlette app
+        app = Starlette()
+
+        @app.route("/protected")
+        async def protected(request: Request) -> PlainTextResponse:
+            user = getattr(request.state, "user", None)
+            if user:
+                return PlainTextResponse(f"Hello {user.username}")
+            return PlainTextResponse("No user")
+
+        # Create a mock auth backend that returns a valid user
+        mock_user = User(
+            username="testuser",
+            uid="test-uid",
+            groups=["test-group"],
+            auth_method="bearer",
+        )
+        mock_auth_backend = Mock()
+        mock_auth_backend.authenticate = AsyncMock(return_value=mock_user)
+
+        # Add authentication middleware
+        app.add_middleware(AuthenticationMiddleware, auth_backend=mock_auth_backend)
+
+        # Create test client
+        client = TestClient(app)
+
+        # Test protected endpoint with valid auth
+        response = client.get(
+            "/protected", headers={"Authorization": "Bearer valid-token"}
+        )
+        assert response.status_code == 200
+        assert response.text == "Hello testuser"
+
+        # Verify authenticate was called
+        mock_auth_backend.authenticate.assert_called_once()
+
+    def test_protected_endpoint_with_invalid_auth(self) -> None:
+        """Test that protected endpoints fail with invalid authentication."""
+        # Create a simple Starlette app
+        app = Starlette()
+
+        @app.route("/protected")
+        async def protected(request: Request) -> PlainTextResponse:
+            return PlainTextResponse("Protected content")
+
+        # Create a mock auth backend that returns None (auth failure)
+        mock_auth_backend = Mock()
+        mock_auth_backend.authenticate = AsyncMock(return_value=None)
+
+        # Add authentication middleware
+        app.add_middleware(AuthenticationMiddleware, auth_backend=mock_auth_backend)
+
+        # Create test client
+        client = TestClient(app)
+
+        # Test protected endpoint with invalid auth
+        response = client.get(
+            "/protected", headers={"Authorization": "Bearer invalid-token"}
+        )
+        assert response.status_code == 401
+        assert response.json() == {"error": "Authentication required"}
+
+        # Verify authenticate was called
+        mock_auth_backend.authenticate.assert_called_once()
+
+    def test_middleware_with_no_auth_backend(self) -> None:
+        """Test middleware behavior with NoAuthBackend."""
+        # Create a simple Starlette app
+        app = Starlette()
+
+        @app.route("/protected")
+        async def protected(request: Request) -> PlainTextResponse:
+            user = getattr(request.state, "user", None)
+            if user:
+                return PlainTextResponse(f"Hello {user.username}")
+            return PlainTextResponse("No user")
+
+        # Use NoAuthBackend
+        no_auth_backend = NoAuthBackend()
+
+        # Add authentication middleware
+        app.add_middleware(AuthenticationMiddleware, auth_backend=no_auth_backend)
+
+        # Create test client
+        client = TestClient(app)
+
+        # Test that all endpoints work with NoAuthBackend
+        response = client.get("/protected")
+        assert response.status_code == 200
+        assert response.text == "Hello dev-user"
+
+    def test_middleware_logs_authentication_failure(self) -> None:
+        """Test that authentication failures are properly logged."""
+        # Create a simple Starlette app
+        app = Starlette()
+
+        @app.route("/protected")
+        async def protected(request: Request) -> PlainTextResponse:
+            return PlainTextResponse("Protected content")
+
+        # Create a mock auth backend that fails
+        mock_auth_backend = Mock()
+        mock_auth_backend.authenticate = AsyncMock(return_value=None)
+
+        # Add authentication middleware
+        app.add_middleware(AuthenticationMiddleware, auth_backend=mock_auth_backend)
+
+        # Create test client
+        client = TestClient(app)
+
+        # Test with no auth header
+        response = client.get("/protected")
+        assert response.status_code == 401
+
+        # Test with auth header
+        response = client.get(
+            "/protected", headers={"Authorization": "Bearer test-token"}
+        )
+        assert response.status_code == 401
+
+        # Verify authenticate was called twice
+        assert mock_auth_backend.authenticate.call_count == 2
+
+    def test_middleware_adds_user_to_request_state(self) -> None:
+        """Test that successful authentication adds user to request state."""
+        # Create a simple Starlette app
+        app = Starlette()
+
+        @app.route("/user-info")
+        async def user_info(request: Request) -> JSONResponse:
+            user = getattr(request.state, "user", None)
+            if user:
+                return JSONResponse(
+                    {
+                        "username": user.username,
+                        "uid": user.uid,
+                        "groups": user.groups,
+                        "auth_method": user.auth_method,
+                    }
+                )
+            return JSONResponse({"error": "No user"})
+
+        # Create a mock user and auth backend
+        mock_user = User(
+            username="testuser",
+            uid="test-uid-123",
+            groups=["group1", "group2"],
+            auth_method="bearer",
+        )
+        mock_auth_backend = Mock()
+        mock_auth_backend.authenticate = AsyncMock(return_value=mock_user)
+
+        # Add authentication middleware
+        app.add_middleware(AuthenticationMiddleware, auth_backend=mock_auth_backend)
+
+        # Create test client
+        client = TestClient(app)
+
+        # Test that user info is accessible in the endpoint
+        response = client.get(
+            "/user-info", headers={"Authorization": "Bearer valid-token"}
+        )
+        assert response.status_code == 200
+
+        user_data = response.json()
+        assert user_data["username"] == "testuser"
+        assert user_data["uid"] == "test-uid-123"
+        assert user_data["groups"] == ["group1", "group2"]
+        assert user_data["auth_method"] == "bearer"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -983,3 +983,84 @@ class TestFastMCPIntegration:
                         "Failed to execute" in response_data["error"]
                         or "Connection failed" in response_data["error"]
                     )
+
+
+class TestOAuthWellKnownEndpoints:
+    """Test OAuth well-known endpoints."""
+
+    def test_oauth_protected_resource_endpoint(self) -> None:
+        """Test OAuth protected resource metadata endpoint."""
+        from starlette.testclient import TestClient
+
+        # Create a test client for the FastMCP app
+        asgi_app = app.streamable_http_app()
+        client = TestClient(asgi_app)
+
+        # Test the OAuth protected resource endpoint
+        response = client.get("/.well-known/oauth-protected-resource")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data["resource_server"] == "proms-mcp"
+        assert "authorization_server" in data
+        assert data["scopes_supported"] == ["read", "write"]
+        assert data["bearer_methods_supported"] == ["header"]
+        assert "resource_documentation" in data
+
+    def test_oauth_authorization_server_endpoint(self) -> None:
+        """Test OAuth authorization server metadata endpoint."""
+        from starlette.testclient import TestClient
+
+        # Create a test client for the FastMCP app
+        asgi_app = app.streamable_http_app()
+        client = TestClient(asgi_app)
+
+        # Test the OAuth authorization server endpoint
+        response = client.get("/.well-known/oauth-authorization-server")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert "issuer" in data
+        assert "authorization_endpoint" in data
+        assert "token_endpoint" in data
+        assert data["scopes_supported"] == ["read", "write"]
+        assert data["response_types_supported"] == ["code"]
+        assert data["grant_types_supported"] == ["authorization_code", "bearer"]
+        assert data["token_endpoint_auth_methods_supported"] == [
+            "client_secret_basic",
+            "bearer",
+        ]
+
+    def test_oauth_endpoints_accessible_without_auth(self) -> None:
+        """Test that OAuth endpoints are accessible without authentication when auth is enabled."""
+        from starlette.testclient import TestClient
+
+        from proms_mcp.auth.middleware import AuthenticationMiddleware
+
+        # Create a test client for the FastMCP app
+        asgi_app = app.streamable_http_app()
+
+        # Mock auth backend that always fails authentication
+        mock_auth_backend = Mock()
+        mock_auth_backend.authenticate = AsyncMock(return_value=None)
+
+        # Wrap with authentication middleware (simulating AUTH_MODE=active)
+        authenticated_app = AuthenticationMiddleware(
+            asgi_app, auth_backend=mock_auth_backend
+        )
+        client = TestClient(authenticated_app)
+
+        # Test that OAuth endpoints are still accessible
+        response = client.get("/.well-known/oauth-protected-resource")
+        assert response.status_code == 200
+
+        response = client.get("/.well-known/oauth-authorization-server")
+        assert response.status_code == 200
+
+        # Test that health and metrics endpoints are also accessible
+        # Note: These endpoints might not exist in the FastMCP app itself,
+        # but the middleware should allow them through
+
+        # Verify that a non-whitelisted endpoint would fail
+        response = client.get("/mcp")
+        assert response.status_code == 401


### PR DESCRIPTION
This pull request adds support for OAuth 2.0 well-known metadata endpoints to improve compatibility with OAuth clients, updates the authentication middleware to allow unauthenticated access to these endpoints, and introduces comprehensive tests to ensure correct authentication behavior and endpoint accessibility.

**OAuth 2.0 Well-Known Endpoints:**
* Added two new endpoints, `/.well-known/oauth-protected-resource` and `/.well-known/oauth-authorization-server`, to provide OAuth 2.0 resource and authorization server metadata, respectively, in `server.py`. These endpoints expose necessary metadata for OAuth client interoperability.

**Authentication Middleware Updates:**
* Updated the authentication middleware in `middleware.py` to exempt the new OAuth well-known endpoints from authentication, in addition to the existing health and metrics endpoints. This ensures these endpoints are always accessible.

**Testing Improvements:**

*Authentication Middleware Tests:*
* Added a comprehensive test suite for the authentication middleware in `test_middleware.py`, covering unprotected/protected endpoint access, authentication success/failure, request state handling, and logging of authentication failures.

*OAuth Endpoint Tests:*
* Added tests for the new OAuth well-known endpoints in `test_server.py`, verifying correct metadata, accessibility without authentication, and proper middleware behavior when authentication is enabled.

**Dependency Updates:**
* Imported `Request` and `JSONResponse` from `starlette` in `server.py` to support the new endpoints.