### PR TITLE
remove partial auth support

### DIFF
--- a/proms_mcp/auth/middleware.py
+++ b/proms_mcp/auth/middleware.py
@@ -20,12 +20,10 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Any, call_next: Any) -> Any:
         """Process request with authentication."""
-        # Skip authentication for health checks, metrics, and OAuth well-known endpoints
+        # Skip authentication for health checks and metrics endpoints
         unprotected_paths = [
             "/health",
             "/metrics",
-            "/.well-known/oauth-protected-resource",
-            "/.well-known/oauth-authorization-server",
         ]
         if request.url.path in unprotected_paths:
             return await call_next(request)

--- a/proms_mcp/server.py
+++ b/proms_mcp/server.py
@@ -14,8 +14,6 @@ from typing import Any
 
 import structlog
 from fastmcp import FastMCP
-from starlette.requests import Request
-from starlette.responses import JSONResponse
 
 from .auth import AuthMode
 from .auth.backends import NoAuthBackend
@@ -38,38 +36,6 @@ app: FastMCP = FastMCP(
     instructions="A lean MCP server providing access to multiple Prometheus instances for metrics analysis and SRE operations.",
     stateless_http=True,
 )
-
-
-# OAuth well-known endpoints for MCP client compatibility
-@app.custom_route("/.well-known/oauth-protected-resource", methods=["GET"])
-async def oauth_protected_resource(request: Request) -> JSONResponse:
-    """OAuth 2.0 protected resource metadata endpoint."""
-    return JSONResponse(
-        {
-            "resource_server": "proms-mcp",
-            "authorization_server": str(request.base_url).rstrip("/"),
-            "scopes_supported": ["read", "write"],
-            "bearer_methods_supported": ["header"],
-            "resource_documentation": str(request.base_url).rstrip("/") + "/health",
-        }
-    )
-
-
-@app.custom_route("/.well-known/oauth-authorization-server", methods=["GET"])
-async def oauth_authorization_server(request: Request) -> JSONResponse:
-    """OAuth 2.0 authorization server metadata endpoint."""
-    base_url = str(request.base_url).rstrip("/")
-    return JSONResponse(
-        {
-            "issuer": base_url,
-            "authorization_endpoint": base_url + "/auth",
-            "token_endpoint": base_url + "/token",
-            "scopes_supported": ["read", "write"],
-            "response_types_supported": ["code"],
-            "grant_types_supported": ["authorization_code", "bearer"],
-            "token_endpoint_auth_methods_supported": ["client_secret_basic", "bearer"],
-        }
-    )
 
 
 # Global readiness state for graceful shutdown

--- a/tests/auth/test_middleware.py
+++ b/tests/auth/test_middleware.py
@@ -28,14 +28,6 @@ class TestAuthenticationMiddleware:
         async def metrics(request: Request) -> PlainTextResponse:
             return PlainTextResponse("# metrics")
 
-        @app.route("/.well-known/oauth-protected-resource")
-        async def oauth_protected_resource(request: Request) -> JSONResponse:
-            return JSONResponse({"resource_server": "test"})
-
-        @app.route("/.well-known/oauth-authorization-server")
-        async def oauth_authorization_server(request: Request) -> JSONResponse:
-            return JSONResponse({"issuer": "test"})
-
         @app.route("/protected")
         async def protected(request: Request) -> PlainTextResponse:
             return PlainTextResponse("Protected content")
@@ -58,14 +50,6 @@ class TestAuthenticationMiddleware:
         response = client.get("/metrics")
         assert response.status_code == 200
         assert response.text == "# metrics"
-
-        response = client.get("/.well-known/oauth-protected-resource")
-        assert response.status_code == 200
-        assert response.json() == {"resource_server": "test"}
-
-        response = client.get("/.well-known/oauth-authorization-server")
-        assert response.status_code == 200
-        assert response.json() == {"issuer": "test"}
 
         # Test protected endpoint - should fail without authentication
         response = client.get("/protected")


### PR DESCRIPTION
well-known endpoints should return 404 so token based auth can happen

This pull request removes support for the OAuth 2.0 well-known endpoints (`/.well-known/oauth-protected-resource` and `/.well-known/oauth-authorization-server`) from both the main server application and the authentication middleware. Corresponding tests and test routes for these endpoints have also been removed or refactored. The authentication middleware now only skips authentication for the `/health` and `/metrics` endpoints.

Key changes:

**Removal of OAuth well-known endpoints:**

* Deleted the implementation of the `/.well-known/oauth-protected-resource` and `/.well-known/oauth-authorization-server` endpoints from `server.py`, including their route handlers and related imports. [[1]](diffhunk://#diff-8931f7b9c10ede0eee3c4e3e9e0949f6f1d6e6e207e2b649706391bc2105de9aL17-L18) [[2]](diffhunk://#diff-8931f7b9c10ede0eee3c4e3e9e0949f6f1d6e6e207e2b649706391bc2105de9aL43-L74)
* Removed test routes for these endpoints from `test_middleware.py`.
* Deleted all tests specifically targeting these OAuth well-known endpoints from `test_server.py`. [[1]](diffhunk://#diff-5620588ecb93aec064fe16ec7e5c10f6669041c927717e0f57b3f9a44ffec5acL988-R992) [[2]](diffhunk://#diff-5620588ecb93aec064fe16ec7e5c10f6669041c927717e0f57b3f9a44ffec5acL1053-R1019)
* Updated the authentication middleware to no longer treat these endpoints as unprotected; only `/health` and `/metrics` remain as unprotected paths.

**Test refactoring:**

* Refactored and renamed test classes and methods to focus on verifying that only `/health` and `/metrics` are accessible without authentication, rather than the removed OAuth endpoints. [[1]](diffhunk://#diff-5620588ecb93aec064fe16ec7e5c10f6669041c927717e0f57b3f9a44ffec5acL988-R992) [[2]](diffhunk://#diff-5620588ecb93aec064fe16ec7e5c10f6669041c927717e0f57b3f9a44ffec5acL1053-R1019) [[3]](diffhunk://#diff-37aedbc8ada0e9ad07f4cd2660acaca1d033451f64e962416172633b2edbc9c9L62-L69)

These changes simplify the codebase by removing unused or unsupported OAuth metadata endpoints and ensure that the authentication middleware's unprotected paths are limited to health and metrics checks.