### PR TITLE
rename metrics so they're prefixed with proms_mcp_

### DIFF
--- a/SPECS.md
+++ b/SPECS.md
@@ -327,11 +327,11 @@ Note: Advanced security patterns were removed to keep the implementation lean. H
 
 **Prometheus Metrics Collected:**
 
-- `mcp_tool_requests_total`: Counter by tool name and status
-- `mcp_tool_request_duration_seconds`: Histogram by tool name with buckets
-- `mcp_server_requests_total`: Counter by HTTP method and endpoint
-- `mcp_datasources_configured`: Gauge of configured datasources
-- `mcp_connected_clients`: Gauge of active client connections (basic tracking)
+- `proms_mcp_tool_requests_total`: Counter by tool name and status
+- `proms_mcp_tool_request_duration_seconds`: Histogram by tool name with buckets
+- `proms_mcp_server_requests_total`: Counter by HTTP method and endpoint
+- `proms_mcp_datasources_configured`: Gauge of configured datasources
+- `proms_mcp_connected_clients`: Gauge of active client connections (basic tracking)
 
 **Implementation Requirements:**
 

--- a/SPECS.md
+++ b/SPECS.md
@@ -177,7 +177,7 @@ All tools must return structured JSON with consistent formatting:
 - **Health Endpoint**: `GET /health` on port 8080 (configurable via HEALTH_METRICS_PORT)
 - **Metrics Endpoint**: `GET /metrics` on port 8080 (Prometheus format)
 - **Implementation**: Dedicated `monitoring.py` module with HTTP server in background thread
-- **Health Response**: JSON with status, uptime, datasource count, connected clients
+- **Health Response**: JSON with status, uptime, datasource count, cached auth entries
 - **Metrics Format**: Standard Prometheus metrics format with histograms and counters
 - **Modular Design**: Separated from main MCP server for clean architecture
 
@@ -331,7 +331,7 @@ Note: Advanced security patterns were removed to keep the implementation lean. H
 - `proms_mcp_tool_request_duration_seconds`: Histogram by tool name with buckets
 - `proms_mcp_server_requests_total`: Counter by HTTP method and endpoint
 - `proms_mcp_datasources_configured`: Gauge of configured datasources
-- `proms_mcp_connected_clients`: Gauge of active client connections (basic tracking)
+- `proms_mcp_cached_auth_entries`: Gauge of cached authentication entries
 
 **Implementation Requirements:**
 

--- a/proms_mcp/auth.py
+++ b/proms_mcp/auth.py
@@ -39,6 +39,11 @@ def clear_auth_cache() -> None:
     _auth_cache.clear()
 
 
+def get_auth_cache_size() -> int:
+    """Get the current size of the authentication cache."""
+    return len(_auth_cache)
+
+
 class AuthMode(Enum):
     """Authentication mode configuration."""
 
@@ -205,4 +210,5 @@ __all__ = [
     "AuthMode",
     "User",
     "OpenShiftUserVerifier",
+    "get_auth_cache_size",
 ]

--- a/proms_mcp/monitoring.py
+++ b/proms_mcp/monitoring.py
@@ -9,6 +9,8 @@ from typing import Any
 
 import structlog
 
+from .auth import get_auth_cache_size
+
 logger = structlog.get_logger()
 
 
@@ -69,7 +71,7 @@ def get_health_data(metrics_data: dict[str, Any]) -> dict[str, Any]:
         "status": "healthy",  # Could be made dynamic based on server state
         "uptime_seconds": time.time() - metrics_data["server_start_time"],
         "datasources_configured": metrics_data["datasources_configured"],
-        "connected_clients": metrics_data["connected_clients"],
+        "cached_auth_entries": get_auth_cache_size(),
     }
 
 
@@ -143,10 +145,12 @@ def get_prometheus_metrics(metrics_data: dict[str, Any]) -> str:
         f"proms_mcp_datasources_configured {metrics_data['datasources_configured']}"
     )
 
-    # Connected clients
-    lines.append("# HELP proms_mcp_connected_clients Number of connected MCP clients")
-    lines.append("# TYPE proms_mcp_connected_clients gauge")
-    lines.append(f"proms_mcp_connected_clients {metrics_data['connected_clients']}")
+    # Cached auth entries
+    lines.append(
+        "# HELP proms_mcp_cached_auth_entries Number of cached authentication entries"
+    )
+    lines.append("# TYPE proms_mcp_cached_auth_entries gauge")
+    lines.append(f"proms_mcp_cached_auth_entries {get_auth_cache_size()}")
 
     return "\n".join(lines) + "\n"
 

--- a/proms_mcp/monitoring.py
+++ b/proms_mcp/monitoring.py
@@ -78,17 +78,21 @@ def get_prometheus_metrics(metrics_data: dict[str, Any]) -> str:
     lines = []
 
     # MCP tool requests total
-    lines.append("# HELP mcp_tool_requests_total Total number of MCP tool requests")
-    lines.append("# TYPE mcp_tool_requests_total counter")
+    lines.append(
+        "# HELP proms_mcp_tool_requests_total Total number of MCP tool requests"
+    )
+    lines.append("# TYPE proms_mcp_tool_requests_total counter")
     for tool, statuses in metrics_data["tool_requests_total"].items():
         for status, count in statuses.items():
             lines.append(
-                f'mcp_tool_requests_total{{tool="{tool}",status="{status}"}} {count}'
+                f'proms_mcp_tool_requests_total{{tool="{tool}",status="{status}"}} {count}'
             )
 
     # MCP tool request duration
-    lines.append("# HELP mcp_tool_request_duration_seconds MCP tool request durations")
-    lines.append("# TYPE mcp_tool_request_duration_seconds histogram")
+    lines.append(
+        "# HELP proms_mcp_tool_request_duration_seconds MCP tool request durations"
+    )
+    lines.append("# TYPE proms_mcp_tool_request_duration_seconds histogram")
     for tool, durations in metrics_data["tool_request_durations"].items():
         if durations:
             # Simple histogram buckets
@@ -108,39 +112,41 @@ def get_prometheus_metrics(metrics_data: dict[str, Any]) -> str:
             for i, (bucket, count) in enumerate(zip(buckets, counts)):
                 cumulative += count
                 lines.append(
-                    f'mcp_tool_request_duration_seconds_bucket{{tool="{tool}",le="{bucket}"}} {cumulative}'
+                    f'proms_mcp_tool_request_duration_seconds_bucket{{tool="{tool}",le="{bucket}"}} {cumulative}'
                 )
 
             lines.append(
-                f'mcp_tool_request_duration_seconds_bucket{{tool="{tool}",le="+Inf"}} {total_count}'
+                f'proms_mcp_tool_request_duration_seconds_bucket{{tool="{tool}",le="+Inf"}} {total_count}'
             )
             lines.append(
-                f'mcp_tool_request_duration_seconds_count{{tool="{tool}"}} {total_count}'
+                f'proms_mcp_tool_request_duration_seconds_count{{tool="{tool}"}} {total_count}'
             )
             lines.append(
-                f'mcp_tool_request_duration_seconds_sum{{tool="{tool}"}} {total_sum}'
+                f'proms_mcp_tool_request_duration_seconds_sum{{tool="{tool}"}} {total_sum}'
             )
 
     # Server requests total
-    lines.append("# HELP mcp_server_requests_total Total number of HTTP requests")
-    lines.append("# TYPE mcp_server_requests_total counter")
+    lines.append("# HELP proms_mcp_server_requests_total Total number of HTTP requests")
+    lines.append("# TYPE proms_mcp_server_requests_total counter")
     for method, endpoints in metrics_data["server_requests_total"].items():
         for endpoint, count in endpoints.items():
             lines.append(
-                f'mcp_server_requests_total{{method="{method}",endpoint="{endpoint}"}} {count}'
+                f'proms_mcp_server_requests_total{{method="{method}",endpoint="{endpoint}"}} {count}'
             )
 
     # Datasources configured
     lines.append(
-        "# HELP mcp_datasources_configured Number of configured Prometheus datasources"
+        "# HELP proms_mcp_datasources_configured Number of configured Prometheus datasources"
     )
-    lines.append("# TYPE mcp_datasources_configured gauge")
-    lines.append(f"mcp_datasources_configured {metrics_data['datasources_configured']}")
+    lines.append("# TYPE proms_mcp_datasources_configured gauge")
+    lines.append(
+        f"proms_mcp_datasources_configured {metrics_data['datasources_configured']}"
+    )
 
     # Connected clients
-    lines.append("# HELP mcp_connected_clients Number of connected MCP clients")
-    lines.append("# TYPE mcp_connected_clients gauge")
-    lines.append(f"mcp_connected_clients {metrics_data['connected_clients']}")
+    lines.append("# HELP proms_mcp_connected_clients Number of connected MCP clients")
+    lines.append("# TYPE proms_mcp_connected_clients gauge")
+    lines.append(f"proms_mcp_connected_clients {metrics_data['connected_clients']}")
 
     return "\n".join(lines) + "\n"
 

--- a/proms_mcp/server.py
+++ b/proms_mcp/server.py
@@ -47,7 +47,6 @@ metrics_data: dict[str, Any] = {
         lambda: defaultdict(int)
     ),  # method -> endpoint -> count
     "datasources_configured": 0,
-    "connected_clients": 0,  # Track active connections
     "server_start_time": time.time(),
 }
 

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -45,11 +45,11 @@ class TestMonitoring:
 
         metrics_text = get_prometheus_metrics(metrics_data)
 
-        assert "# HELP mcp_tool_requests_total" in metrics_text
-        assert "# TYPE mcp_tool_requests_total counter" in metrics_text
-        assert "# HELP mcp_datasources_configured" in metrics_text
-        assert "mcp_datasources_configured 0" in metrics_text
-        assert "mcp_connected_clients 0" in metrics_text
+        assert "# HELP proms_mcp_tool_requests_total" in metrics_text
+        assert "# TYPE proms_mcp_tool_requests_total counter" in metrics_text
+        assert "# HELP proms_mcp_datasources_configured" in metrics_text
+        assert "proms_mcp_datasources_configured 0" in metrics_text
+        assert "proms_mcp_connected_clients 0" in metrics_text
 
     def test_get_prometheus_metrics_with_data(self) -> None:
         """Test Prometheus metrics generation with sample data."""
@@ -75,31 +75,31 @@ class TestMonitoring:
 
         # Check tool requests
         assert (
-            'mcp_tool_requests_total{tool="list_datasources",status="success"} 5'
+            'proms_mcp_tool_requests_total{tool="list_datasources",status="success"} 5'
             in metrics_text
         )
         assert (
-            'mcp_tool_requests_total{tool="query_instant",status="error"} 1'
+            'proms_mcp_tool_requests_total{tool="query_instant",status="error"} 1'
             in metrics_text
         )
 
         # Check server requests
         assert (
-            'mcp_server_requests_total{method="GET",endpoint="/health"} 10'
+            'proms_mcp_server_requests_total{method="GET",endpoint="/health"} 10'
             in metrics_text
         )
 
         # Check gauges
-        assert "mcp_datasources_configured 2" in metrics_text
-        assert "mcp_connected_clients 1" in metrics_text
+        assert "proms_mcp_datasources_configured 2" in metrics_text
+        assert "proms_mcp_connected_clients 1" in metrics_text
 
         # Check histogram data
         assert (
-            'mcp_tool_request_duration_seconds_count{tool="list_datasources"} 3'
+            'proms_mcp_tool_request_duration_seconds_count{tool="list_datasources"} 3'
             in metrics_text
         )
         assert (
-            'mcp_tool_request_duration_seconds_sum{tool="list_datasources"} 0.45'
+            'proms_mcp_tool_request_duration_seconds_sum{tool="list_datasources"} 0.45'
             in metrics_text
         )
 
@@ -128,19 +128,19 @@ class TestMonitoring:
         # 800ms (0.8s) -> le="1.0" bucket: 1 + 1 = 2 (but algorithm is different)
         # Let's just check the structure is correct
         assert (
-            'mcp_tool_request_duration_seconds_bucket{tool="test_tool",le="0.1"} 1'
+            'proms_mcp_tool_request_duration_seconds_bucket{tool="test_tool",le="0.1"} 1'
             in metrics_text
         )
         assert (
-            'mcp_tool_request_duration_seconds_bucket{tool="test_tool",le="+Inf"} 4'
+            'proms_mcp_tool_request_duration_seconds_bucket{tool="test_tool",le="+Inf"} 4'
             in metrics_text
         )
         assert (
-            'mcp_tool_request_duration_seconds_count{tool="test_tool"} 4'
+            'proms_mcp_tool_request_duration_seconds_count{tool="test_tool"} 4'
             in metrics_text
         )
         assert (
-            'mcp_tool_request_duration_seconds_sum{tool="test_tool"} 14.85'
+            'proms_mcp_tool_request_duration_seconds_sum{tool="test_tool"} 14.85'
             in metrics_text
         )
 
@@ -195,7 +195,7 @@ class TestMonitoring:
         # Verify +Inf bucket
         assert 'le="+Inf"' in metrics_text
         assert (
-            'mcp_tool_request_duration_seconds_count{tool="complex_tool"} 7'
+            'proms_mcp_tool_request_duration_seconds_count{tool="complex_tool"} 7'
             in metrics_text
         )
 
@@ -387,15 +387,15 @@ class TestHealthMetricsIntegration:
 
         # Verify counts are correct
         assert (
-            'mcp_tool_request_duration_seconds_count{tool="fast_tool"} 3'
+            'proms_mcp_tool_request_duration_seconds_count{tool="fast_tool"} 3'
             in metrics_text
         )
         assert (
-            'mcp_tool_request_duration_seconds_count{tool="slow_tool"} 2'
+            'proms_mcp_tool_request_duration_seconds_count{tool="slow_tool"} 2'
             in metrics_text
         )
         assert (
-            'mcp_tool_request_duration_seconds_count{tool="single_tool"} 1'
+            'proms_mcp_tool_request_duration_seconds_count{tool="single_tool"} 1'
             in metrics_text
         )
 
@@ -417,15 +417,15 @@ class TestHealthMetricsIntegration:
 
         # Zero values should still be included
         assert (
-            'mcp_tool_requests_total{tool="zero_tool",status="success"} 0'
+            'proms_mcp_tool_requests_total{tool="zero_tool",status="success"} 0'
             in metrics_text
         )
         assert (
-            'mcp_server_requests_total{method="GET",endpoint="/zero-endpoint"} 0'
+            'proms_mcp_server_requests_total{method="GET",endpoint="/zero-endpoint"} 0'
             in metrics_text
         )
-        assert "mcp_datasources_configured 0" in metrics_text
-        assert "mcp_connected_clients 0" in metrics_text
+        assert "proms_mcp_datasources_configured 0" in metrics_text
+        assert "proms_mcp_connected_clients 0" in metrics_text
 
     def test_prometheus_metrics_large_dataset(self) -> None:
         """Test metrics generation with large datasets."""
@@ -453,8 +453,8 @@ class TestHealthMetricsIntegration:
         metrics_text = get_prometheus_metrics(metrics_data)
 
         # Verify large values are handled correctly
-        assert "mcp_datasources_configured 1000" in metrics_text
-        assert "mcp_connected_clients 500" in metrics_text
+        assert "proms_mcp_datasources_configured 1000" in metrics_text
+        assert "proms_mcp_connected_clients 500" in metrics_text
 
         # Verify some of the generated metrics exist
         assert 'tool="tool_10"' in metrics_text

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -773,7 +773,6 @@ class TestFastMCPIntegration:
             "tool_request_durations",
             "server_requests_total",
             "datasources_configured",
-            "connected_clients",
             "server_start_time",
         ]
 
@@ -785,7 +784,7 @@ class TestFastMCPIntegration:
         assert isinstance(metrics_data["tool_request_durations"], dict)
         assert isinstance(metrics_data["server_requests_total"], dict)
         assert isinstance(metrics_data["datasources_configured"], int)
-        assert isinstance(metrics_data["connected_clients"], int)
+
         assert isinstance(metrics_data["server_start_time"], float)
 
     @pytest.mark.asyncio


### PR DESCRIPTION
This pull request standardizes the naming convention for all Prometheus metrics in the MCP monitoring codebase by prefixing them with `proms_`. This change improves clarity and consistency across metric names, and ensures that both the implementation and tests reflect the new naming. The updates affect documentation, metric generation logic, and all related tests.

**Prometheus metric naming standardization:**

* Updated all metric names in `proms_mcp/monitoring.py` to use the `proms_` prefix instead of `mcp_`, including counters, histograms, and gauges. [[1]](diffhunk://#diff-6302e9857acdce2477b3d8c8cdec3587c4c6454c41b3480dd00db75e577d53a1L81-R95) [[2]](diffhunk://#diff-6302e9857acdce2477b3d8c8cdec3587c4c6454c41b3480dd00db75e577d53a1L111-R149)
* Changed metric references in the documentation (`SPECS.md`) to match the new naming convention.

**Test suite updates:**

* Modified all assertions in `tests/test_monitoring.py` to expect the new `proms_` metric names, ensuring test coverage matches the updated implementation. [[1]](diffhunk://#diff-12dcda947d179f832810bddddd3e5374835fd550255214103e8e06612e1edee4L48-R52) [[2]](diffhunk://#diff-12dcda947d179f832810bddddd3e5374835fd550255214103e8e06612e1edee4L78-R102) [[3]](diffhunk://#diff-12dcda947d179f832810bddddd3e5374835fd550255214103e8e06612e1edee4L131-R143) [[4]](diffhunk://#diff-12dcda947d179f832810bddddd3e5374835fd550255214103e8e06612e1edee4L198-R198) [[5]](diffhunk://#diff-12dcda947d179f832810bddddd3e5374835fd550255214103e8e06612e1edee4L390-R398) [[6]](diffhunk://#diff-12dcda947d179f832810bddddd3e5374835fd550255214103e8e06612e1edee4L420-R428) [[7]](diffhunk://#diff-12dcda947d179f832810bddddd3e5374835fd550255214103e8e06612e1edee4L456-R457)